### PR TITLE
fix: require `~` prefix to import directly from node_modules/bower

### DIFF
--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -33,9 +33,17 @@ gulp.task("styles", function() {
         .pipe($.sourcemaps.init()) // start sourcemap processing
         .pipe($.sass({
             includePaths: [config.bowerPackageFolder],
-            importer: moduleImporter({
-                basedir: process.cwd()
-            })
+            importer: [
+                function(url, prev, done) {
+                    if(url.indexOf("~") === 0 && url.indexOf("/") !== 1) {
+                        moduleImporter({
+                            basedir: process.cwd()
+                        })(url.substr(1), prev, done);
+                    } else {
+                        return null;
+                    }
+                }
+            ]
         })) // compile the sass
         .on("error", errorHandler) // if there are errors during sass compile, call errorHandler
         .pipe(postcss(processors))


### PR DESCRIPTION
Do we think that requiring a ~ prefix is a good idea? As in `@import "~colonial-branding";` instead of `@import "colonial-branding";`. This appears to be the way that sass-loader for webpack does it, so our code would still be compatible with webpack should we switch in the future. 

Closes #19 
/cc @Keale2 @slkennedy
